### PR TITLE
Fix select box CSS bug

### DIFF
--- a/themes/Default/phpliteadmin.css
+++ b/themes/Default/phpliteadmin.css
@@ -81,6 +81,11 @@ input, select, textarea
 	-moz-border-radius:5px;
 	padding:3px;
 }
+
+select {
+    width: 100%;
+}
+
 /* just input buttons */
 input.btn
 {


### PR DESCRIPTION
Found a CSS bug causing the selection box goes beyond the wrapper div, it occurs when the database selection is 9 or above.

![image](https://user-images.githubusercontent.com/4969689/205131937-0f00dddd-a1b0-4800-9a03-6fe4b2317bfd.png)
